### PR TITLE
Fix: Correct areas on image not showing when developer mode is enabled

### DIFF
--- a/templates/ppq.hbs
+++ b/templates/ppq.hbs
@@ -6,7 +6,7 @@
 
     			{{#if _developerMode}}
 	    			{{#each _items}}
-	    				{{#if ../../desktopLayout}}
+	    				{{#if ../desktopLayout}}
 				    		<div class="ppq-correct-zone" style="left:{{desktop.left}}%; top:{{desktop.top}}%; width:{{desktop.width}}%; height:{{desktop.height}}%;"></div>
 				    	{{else}}
 				    		<div class="ppq-correct-zone" style="left:{{mobile.left}}%; top:{{mobile.top}}%; width:{{mobile.width}}%; height:{{mobile.height}}%;"></div>


### PR DESCRIPTION
Fix: Correct areas on image not showing when developer mode is enabled. Always defaulting to mobile coordinates.